### PR TITLE
Specify executionRoleArn for ECS task deploys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,33 @@
-plugins {
-    id "java"
-    id "org.jenkins-ci.jpi" version "0.18.1"
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "gradle.plugin.org.jenkins-ci.tools:gradle-jpi-plugin:0.28.1"
+    }
+    
+    ext {
+        lombokVersion = '1.18.4'
+    }
 }
+
+apply plugin: "java"
+apply plugin: "org.jenkins-ci.jpi"
 
 group = "org.jenkins-ci.plugins"
 description = "AWS Elastic Container Service deployment plugin"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 jenkinsPlugin {
     shortName = "aws-ecs-deploy"
     displayName = description
     url = "https://github.com/zeroturnaround/aws-ecs-deploy-jenkins-plugin"
 
-    coreVersion = "1.609.3"
+    coreVersion = "2.150.2"
 
     disabledTestInjection = true
 
@@ -29,17 +42,21 @@ jenkinsPlugin {
 
 repositories {
     jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.16.10"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
-    compileOnly "com.amazonaws:aws-java-sdk-ecs:1.11.68"
+    compileOnly "com.amazonaws:aws-java-sdk-ecs:1.11.486"
 
-    compile "com.jayway.jsonpath:json-path:2.2.0"
+    compile "com.jayway.jsonpath:json-path:2.4.0"
 
-    jenkinsPlugins "org.jenkins-ci.plugins:token-macro:1.5.1@jar"
-    jenkinsPlugins "org.jenkins-ci.plugins:aws-java-sdk:1.11.68@jar"
-    jenkinsPlugins "org.jenkins-ci.plugins:credentials:1.21@jar"
-    jenkinsPlugins "org.jenkins-ci.plugins:aws-credentials:1.16@jar"
+    jenkinsPlugins "org.jenkins-ci.plugins:token-macro:2.5@jar"
+    jenkinsPlugins "org.jenkins-ci.plugins:aws-java-sdk:1.11.457@jar"
+    jenkinsPlugins "org.jenkins-ci.plugins:credentials:2.1.18@jar"
+    jenkinsPlugins "org.jenkins-ci.plugins:aws-credentials:1.24@jar"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip

--- a/src/main/java/com/zeroturnaround/jenkins/plugin/ecs/deploy/AWSECSPublisher.java
+++ b/src/main/java/com/zeroturnaround/jenkins/plugin/ecs/deploy/AWSECSPublisher.java
@@ -61,7 +61,7 @@ public class AWSECSPublisher extends Builder {
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         AmazonWebServicesCredentials credentials = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(AmazonWebServicesCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, (List<DomainRequirement>) null),
+                CredentialsProvider.lookupCredentials(AmazonWebServicesCredentials.class, Jenkins.get(), ACL.SYSTEM, (List<DomainRequirement>) null),
                 CredentialsMatchers.withId(credentialsId)
         );
 
@@ -105,7 +105,7 @@ public class AWSECSPublisher extends Builder {
         }
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup<?> context) {
-            AccessControlled accessControlled = context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance();
+            AccessControlled accessControlled = context instanceof AccessControlled ? (AccessControlled) context : Jenkins.get();
 
             if (!accessControlled.hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();

--- a/src/main/java/com/zeroturnaround/jenkins/plugin/ecs/deploy/steps/RegisterTaskDefinitionStep.java
+++ b/src/main/java/com/zeroturnaround/jenkins/plugin/ecs/deploy/steps/RegisterTaskDefinitionStep.java
@@ -43,6 +43,8 @@ public class RegisterTaskDefinitionStep extends ECSStep {
 
     private final String family;
 
+    private final String roleArn;
+
     private final String taskDefinitionFile;
 
     private final String taskDefinitionId;
@@ -83,7 +85,7 @@ public class RegisterTaskDefinitionStep extends ECSStep {
         }
 
         RegisterTaskDefinitionRequest request = new RegisterTaskDefinitionRequest()
-                .withContainerDefinitions(taskDefinition.getContainerDefinitions())
+                .withContainerDefinitions(taskDefinition.getContainerDefinitions()).withExecutionRoleArn(roleArn)
                 .withVolumes(taskDefinition.getVolumes());
 
         try {

--- a/src/main/resources/com/zeroturnaround/jenkins/plugin/ecs/deploy/steps/RegisterTaskDefinitionStep/config.jelly
+++ b/src/main/resources/com/zeroturnaround/jenkins/plugin/ecs/deploy/steps/RegisterTaskDefinitionStep/config.jelly
@@ -4,6 +4,10 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry title="Role ARN" field="roleArn">
+        <f:textbox />
+    </f:entry>
+
     <f:section title="Task definition source">
         <f:radioBlock name="taskDefinitionSource" value="FILE" checked="${instance.isTaskDefinitionSource('FILE')}" title="From file" inline="true">
             <f:nested>


### PR DESCRIPTION
Fix for

`18:27:57 com.amazonaws.services.ecs.model.ClientException: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'. (Service: AmazonECS; Status Code: 400; Error Code: ClientException; Request ID: 82e2e3fc-1d99-11e9-81dc-b15c5ed7c573)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1695)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1350)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1101)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:758)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:732)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:714)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:674)
18:27:57 	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:656)
18:27:57 	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:520)
18:27:57 	at com.amazonaws.services.ecs.AmazonECSClient.doInvoke(AmazonECSClient.java:3265)
18:27:57 	at com.amazonaws.services.ecs.AmazonECSClient.invoke(AmazonECSClient.java:3232)
18:27:57 	at com.amazonaws.services.ecs.AmazonECSClient.invoke(AmazonECSClient.java:3221)
18:27:57 	at com.amazonaws.services.ecs.AmazonECSClient.executeRegisterTaskDefinition(AmazonECSClient.java:2284)
18:27:57 	at com.amazonaws.services.ecs.AmazonECSClient.registerTaskDefinition(AmazonECSClient.java:2255)
18:27:57 	at com.zeroturnaround.jenkins.plugin.ecs.deploy.steps.RegisterTaskDefinitionStep.perform(RegisterTaskDefinitionStep.java:95)
18:27:57 	at com.zeroturnaround.jenkins.plugin.ecs.deploy.AWSECSPublisher.perform(AWSECSPublisher.java:77)
18:27:57 	at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:45)
18:27:57 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
18:27:57 	at hudson.model.Build$BuildExecution.build(Build.java:206)
18:27:57 	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
18:27:57 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
18:27:57 	at hudson.model.Run.execute(Run.java:1810)
18:27:57 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
18:27:57 	at hudson.model.ResourceController.execute(ResourceController.java:97)
18:27:57 	at hudson.model.Executor.run(Executor.java:429)`